### PR TITLE
Remove surrounding src attribute spacing before processing

### DIFF
--- a/Plugin/BlockPlugin.php
+++ b/Plugin/BlockPlugin.php
@@ -100,6 +100,8 @@ class BlockPlugin
                 </noscript>';
             }
 
+            $html = preg_replace('/(<img[^>]*)\s+src\s*=\s*("|\')\s*(.*?)\s*\2([^>]*>)/i', '$1 src=$2$3$2$4', $html);
+
             $html = preg_replace('#<img(?!\s+mfdislazy)([^>]*)(?:\ssrc="([^"]*)")([^>]*)\/?>#isU', '<img ' .
                 ' data-original="$2" $1 $3/>
                ' . $noscript, $html);


### PR DESCRIPTION
The extension was not properly providing lazyloading functionality when there was some spacing surrounding the '=' or the src attribute inside img tags.